### PR TITLE
Change MAC Address to use an array rather than default in utils folder

### DIFF
--- a/src/main/java/frc/lib/util/MACAddress.java
+++ b/src/main/java/frc/lib/util/MACAddress.java
@@ -14,7 +14,7 @@ import java.net.NetworkInterface;
  * Add your docs here.
  */
 public class MACAddress {
-    public byte[] mac;
+    private byte[] mac;
     public MACAddress() {
         try {
             InetAddress address = InetAddress.getLocalHost();

--- a/src/main/java/frc/lib/util/MACConfigChooser.java
+++ b/src/main/java/frc/lib/util/MACConfigChooser.java
@@ -11,21 +11,27 @@ package frc.lib.util;
  * Add your docs here.
  */
 public class MACConfigChooser {
-    public String constraintsPath;
-    public String robotmapPath;
-    public MACConfigChooser(byte[] mac) {
+    private String constraintsPath;
+    private String robotmapPath;
+    public MACConfigChooser(byte[] mac, String[] macs, String[] constraintsPaths, String[] mapPaths) {
         StringBuilder builder = new StringBuilder();
         for(int i = 0; i < mac.length; i++) {
           builder.append(String.format("%02X%s", mac[i], (i < mac.length - 1) ? "-" : ""));
         }
         System.out.println("MAC: " + builder.toString());
-        if(builder.toString().equals("00-80-2F-19-0C-F3")) {
-          constraintsPath = "/home/lvuser/deploy/greenBox/greenBoxConstraints.properties";
-          robotmapPath = "/home/lvuser/deploy/greenBox/greenBoxRobotmap.properties";
-        } else {
-          System.out.println("Unrecognized MAC Address");
-          constraintsPath = null;
-          robotmapPath = null;
+        for(int i = 0; i < macs.length; i++) {
+            if(builder.toString().equals(macs[i])) {
+                this.constraintsPath = constraintsPaths[i];
+                this.robotmapPath = mapPaths[i];
+                break;
+            }
+        }
+        if(constraintsPath == null) {
+            constraintsPath = "/home/lvuser/deploy/greenBox/greenBoxConstraints.properties";
+        }
+
+        if(robotmapPath == null) {
+            robotmapPath = "/home/lvuser/deploy/greenBox/greenBoxRobotmap.properties";
         }
     }
 

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -26,11 +26,11 @@ import frc.robot.subsystems.DriveSubsystem;
  */
 public class Robot extends TimedRobot {
   //always declare properties objects before subsystems or else it will fail to instantiate
-  public static MACAddress m_macaddress = new MACAddress();
-  public static MACConfigChooser m_macconfigchooser = new MACConfigChooser(m_macaddress.mac);
-  public static ConstraintsProperties m_constraintsProperties = new ConstraintsProperties(m_macconfigchooser.constraintsPath);
-  public static RobotMapProperties m_robotMapProperties = new RobotMapProperties(m_macconfigchooser.robotmapPath);
-  public static DriveSubsystem driveSubsystem = new DriveSubsystem();
+  public static MACAddress m_macaddress;
+  public static MACConfigChooser m_macconfigchooser;
+  public static ConstraintsProperties m_constraintsProperties;
+  public static RobotMapProperties m_robotMapProperties;
+  public static DriveSubsystem driveSubsystem;
   public static OI m_oi;
 
   Command m_autonomousCommand;
@@ -42,6 +42,17 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotInit() {
+    String macArray[] = {"00-80-2F-19-0C-F3", "00-80-2F-19-0C-F5", "00-80-2F-19-0C-F4"};
+    String constraintsPaths[] = {"/home/lvuser/deploy/greenBox/greenBoxConstraints.properties", "/home/lvuser/deploy/practiceBot/practiceBotConstraints.properties", "/home/lvuser/deploy/compBot/compBotConstraints.properties"};
+    String mapPaths[] = {"/home/lvuser/deploy/greenBox/greenBoxRobotmap.properties", "/home/lvuser/deploy/practiceBot/practiceBotRobotmap.properties", "/home/lvuser/deploy/compBot/compBotRobotmap.properties"};
+    
+    m_macaddress = new MACAddress();
+    m_macconfigchooser = new MACConfigChooser(m_macaddress.getMACAddress(), macArray, constraintsPaths, mapPaths);
+    
+    m_constraintsProperties = new ConstraintsProperties(m_macconfigchooser.getConstraintsPath());
+    m_robotMapProperties = new RobotMapProperties(m_macconfigchooser.getRobotmapPath());
+
+    driveSubsystem = new DriveSubsystem();
     m_oi = new OI();
     // m_chooser.setDefaultOption("Default Auto", new ExampleCommand());
     // // chooser.addOption("My Auto", new MyAutoCommand());

--- a/src/main/java/frc/robot/properties/ConstraintsProperties.java
+++ b/src/main/java/frc/robot/properties/ConstraintsProperties.java
@@ -8,6 +8,9 @@
 package frc.robot.properties;
 
 import java.util.Properties;
+
+import edu.wpi.first.wpilibj.DriverStation;
+
 import java.io.InputStream;
 import java.io.FileInputStream;
 /**
@@ -34,6 +37,7 @@ public class ConstraintsProperties {
             PIDTolerance = Double.parseDouble(properties.getProperty("drive_subsystem_PIDTolerance"));
         } catch(Exception e) {
             e.printStackTrace();
+            DriverStation.reportError(e.getMessage(), true);
         }
     }
 

--- a/src/main/java/frc/robot/properties/RobotMapProperties.java
+++ b/src/main/java/frc/robot/properties/RobotMapProperties.java
@@ -8,6 +8,9 @@
 package frc.robot.properties;
 
 import java.util.Properties;
+
+import edu.wpi.first.wpilibj.DriverStation;
+
 import java.io.InputStream;
 import java.io.FileInputStream;
 
@@ -43,6 +46,7 @@ public class RobotMapProperties {
             // System.out.println(left_slave_one);
         } catch (Exception e) {
             e.printStackTrace();
+            DriverStation.reportError(e.getMessage(), true);
         }
         
     }


### PR DESCRIPTION
Added arrays containing MAC Addresses for roboRIOs and the paths for their respective config files.  Changed MACConfigChooser.java to no longer default to the null options due to a string comparison issue.    The integer parsing in RobotMapProperties.java now no longer throws an exception due to being unable to find a source.